### PR TITLE
chore: 更新 README 文档，添加安装说明和平台支持信息

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -14,6 +14,31 @@ Amux Desktop 是一个基于 Electron 的跨平台桌面客户端，提供 LLM A
 - **自动启动**: 支持开机自启动
 - **配置导入导出**: 方便的配置备份和迁移
 
+## 安装
+
+### macOS
+
+从 Release 页面下载 `.dmg` 文件后，将应用拖入 Applications 文件夹。
+
+首次打开应用时，macOS 可能会提示"无法打开，因为无法验证开发者"。这是因为应用未经过 Apple 公证。请运行以下命令解除隔离属性：
+
+```bash
+sudo xattr -dr com.apple.quarantine /Applications/Amux.app
+```
+
+然后重新打开应用即可正常使用。
+
+### Windows
+
+从 Release 页面下载 `.exe` 安装程序，双击运行即可安装。
+
+### Linux
+
+从 Release 页面下载 `.AppImage` 或 `.deb` 文件：
+
+- **AppImage**: 添加执行权限后直接运行 `chmod +x Amux-*.AppImage && ./Amux-*.AppImage`
+- **deb**: 使用 `sudo dpkg -i Amux-*.deb` 安装
+
 ## 快速开始
 
 ### 开发环境


### PR DESCRIPTION
  docs: add desktop app installation guide

  Add installation instructions for macOS, Windows and Linux.
  macOS requires running `xattr -dr com.apple.quarantine` to bypass Gatekeeper
  since the app is not notarized by Apple.
  
  docs: 添加桌面应用安装指南

  添加 macOS、Windows 和 Linux 的安装说明。
  由于应用未经 Apple 公证，macOS 用户需运行 xattr 命令解除 Gatekeeper 隔离限制。